### PR TITLE
use full referrar url to return after login

### DIFF
--- a/flask_cas/__init__.py
+++ b/flask_cas/__init__.py
@@ -96,7 +96,7 @@ def login_required(function):
     @wraps(function)
     def wrap(*args, **kwargs):
         if 'CAS_USERNAME' not in flask.session:
-            flask.session['CAS_AFTER_LOGIN_SESSION_URL'] = flask.request.path
+            flask.session['CAS_AFTER_LOGIN_SESSION_URL'] = flask.request.script_root+ flask.request.full_path
             return login()
         else:
             return function(*args, **kwargs)


### PR DESCRIPTION
If flask app is installed in a subdirectory and accessed with a WSGIScriptAlias to a path in the URL as http://mydomain.com/mypath/ then the url to redirect after login is redirecting to "/" which refers to http://mydomain.com/. This pull request will solve this problem by using the full path and script root.

It passes all the tests.